### PR TITLE
Add new cpu case of wrong cpu topology

### DIFF
--- a/libvirt/tests/cfg/cpu/wrong_topology.cfg
+++ b/libvirt/tests/cfg/cpu/wrong_topology.cfg
@@ -1,0 +1,13 @@
+- cpu.wrong_topology:
+    type = wrong_topology
+    start_vm = no
+    status_error = yes
+    variants:
+        - one_cluster:
+            vcpu = 15
+            cpu_attrs = {'topology': {'sockets': '2', 'dies': '2', 'clusters': '1', 'cores': '2', 'threads': '2'}, 'mode': 'host-passthrough'}
+            err_msg = CPU topology doesn't match maximum vcpu count
+        - multi_clusters:
+            vcpu = 32
+            cpu_attrs = {'topology': {'sockets': '2', 'dies': '2', 'clusters': '2', 'cores': '2', 'threads': '2'}, 'mode': 'host-passthrough'}
+            err_msg = clusters > 1 not supported by this machine's CPU topology

--- a/libvirt/tests/src/cpu/wrong_topology.py
+++ b/libvirt/tests/src/cpu/wrong_topology.py
@@ -1,0 +1,51 @@
+import logging
+
+from virttest import utils_misc
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test Define VM with wrong cpu topology
+    """
+    vm_name = params.get('main_vm')
+
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    tmp_vm_name = 'tmp-vm-' + utils_misc.generate_random_string(3)
+    vcpu = int(params.get('vcpu'))
+    cpu_attrs = eval(params.get('cpu_attrs', {}))
+    status_error = 'yes' == params.get('status_error', 'no')
+    err_msg = params.get('err_msg')
+
+    try:
+        tmp_vmxml = vmxml.copy()
+        tmp_vmxml.setup_attrs(cpu=cpu_attrs)
+        tmp_vmxml.vcpu = vcpu
+
+        tmp_vmxml.vm_name = tmp_vm_name
+        tmp_vmxml.del_uuid()
+        osxml = tmp_vmxml.os
+        os_attrs = osxml.fetch_attrs()
+        for k, v in list(os_attrs.items()):
+            if k.startswith('nvram'):
+                os_attrs.pop(k)
+        new_os = vm_xml.VMOSXML()
+        new_os.setup_attrs(**os_attrs)
+        tmp_vmxml.os = new_os
+
+        tmp_vmxml.xmltreefile.write()
+        logging.debug(tmp_vmxml)
+
+        result = virsh.create(tmp_vmxml.xml, debug=True)
+        libvirt.check_exit_status(result, status_error)
+        libvirt.check_result(result, err_msg)
+
+    finally:
+        bkxml.sync()


### PR DESCRIPTION
VIRT-17939 - [topology] Define or start VM with wrong cpu topology

Test result
(1/2) type_specific.local.cpu.wrong_topology.one_cluster: STARTED
(1/2) type_specific.local.cpu.wrong_topology.one_cluster: PASS (10.17 s)
(2/2) type_specific.local.cpu.wrong_topology.multi_clusters: STARTED
(2/2) type_specific.local.cpu.wrong_topology.multi_clusters: PASS (11.22 s)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced tests to validate VM creation with incorrect CPU topology configurations, covering scenarios such as mismatched vCPU counts and unsupported multi-cluster setups.
  * Added configuration options for specifying expected error messages and CPU topology variants in the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->